### PR TITLE
Add OPEA Roadmap

### DIFF
--- a/roadmap/2024.md
+++ b/roadmap/2024.md
@@ -1,0 +1,126 @@
+## OPEA 2024 Roadmap
+
+### Milestone 1 (May 2nd to May 31st)
+
+- [x] Components contribution
+    - [x] ASR
+    - [x] Data Prep
+    - [x] Embedding
+    - [x] Guardrails
+    - [x] LLM(Gaudi TGI)
+    - [x] RAG Rerank
+    - [x] RAG Retrieval
+    - [x] TTS
+    - [x] RAG VectorDB
+    - [x] Open Telemetry support
+
+- [x] UseCases/Examples
+    - [x] ChatQnA
+    - [x] CodeGen
+    - [x] CodeTrans 
+
+- [ ] Cloud Native
+    - [ ] OneClickOPEA on ChatQnA
+    - [ ] OneClickOPEA on CodeGen
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] lm-eval-harness
+    - [ ] bigcode-eval-harness
+    - [ ] End2End evaluation on GenAIComps & GenAIExamples
+    - [ ] RAG evaluation
+
+### Milestone 2 (June 3rd to June 28st)
+
+- [ ] Components contribution
+    - [ ] LLM on Xeon by vLLM + Ray, Ollama
+    - [ ] OVMS
+    - [ ] Prompting
+    - [ ] User Feedback Management
+    - [ ] MI6 Mega Components(MI6 RAG Service)
+
+- [ ] UseCases/Examples
+    - [ ] DocSum
+    - [ ] SearchQnA
+    - [ ] FAQGen 
+    - [ ] End-to-end RAG example using OPEA on Xeon and cloud
+
+- [ ] Cloud Native
+    - [ ] OneClickOPEA on 2 or more examples
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] End2End evaluation on GenAIComps & GenAIExamples
+
+### Milestone 3 (July 1st to July 26st)
+
+- [ ] Components contribution
+    - [ ] LLM on Gaudi by vLLM + Ray
+    - [ ] LVM on Gaudi by vLLM + Ray
+    - [ ] VectorDB(svs)
+    - [ ] Telemetry
+
+- [ ] UseCases/Examples
+    - [ ] VisualQnA
+    - [ ] Windows Desktop App for AIPC
+
+- [ ] Cloud Native
+    - [ ] OpenShift enablement
+    - [ ] GenAI Microservice Connector
+    - [ ] OneClickOPEA on 3 or more examples
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] End2End evaluation on GenAIComps & GenAIExamples
+
+### Milestone 4 (July 29th to Aug 23rd)
+
+- [ ] Components contribution
+    - [ ] Documentation
+    - [ ] Automation test script
+
+- [ ] UseCases/Examples
+    - [ ] Documentation
+    - [ ] Automation test script
+
+- [ ] Cloud Native
+    - [ ] K8s Resource Management
+    - [ ] Documentation
+    - [ ] AutoScaler Analysis
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] End2End evaluation on GenAIComps & GenAIExamples
+
+### Milestone 5 (Aug 27th to Dec 27th)
+
+- [ ] Components contribution
+    - [ ] More micro service components for image and video
+
+- [ ] UseCases/Examples
+    - [ ] More use cases like language translation and AudioQnA
+
+- [ ] Cloud Native
+    - [ ] Docker Containerization through Docker Composer
+    - [ ] Static tuning on Resource management for deployment
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] End2End evaluation 
+
+
+### Milestone 6 (Jan 6th to Aug 29th, 2025)
+
+- [ ] Components contribution
+    - [ ] More micro service components per community request
+
+- [ ] UseCases/Examples
+    - [ ] No code solution (GenAIStudio) 
+    - [ ] OPEA Model Hub
+
+- [ ] Cloud Native
+    - [ ] Dynamic tuning on Resource management through K8s
+
+- [ ] Evaluation & Others
+    - [ ] CICD & Validation
+    - [ ] End2End evaluation 


### PR DESCRIPTION
This PR is used to record OPEA 2024 roadmap for community. Note it's subject to change per request.