### PR TITLE
Update 2024 OPEA roadmap

### DIFF
--- a/roadmap/2024.md
+++ b/roadmap/2024.md
@@ -1,6 +1,6 @@
 ## OPEA 2024 Roadmap
 
-### Milestone 1 (May 2nd to May 31st)
+### Milestone 1 (May)
 
 - [x] Components contribution
     - [x] ASR
@@ -30,7 +30,7 @@
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
     - [ ] RAG evaluation
 
-### Milestone 2 (June 3rd to June 28st)
+### Milestone 2 (June)
 
 - [ ] Components contribution
     - [ ] LLM on Xeon by vLLM + Ray, Ollama
@@ -52,7 +52,7 @@
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 3 (July 1st to July 26st)
+### Milestone 3 (July)
 
 - [ ] Components contribution
     - [ ] LLM on Gaudi by vLLM + Ray
@@ -73,7 +73,7 @@
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 4 (July 29th to Aug 23rd)
+### Milestone 4 (Aug)
 
 - [ ] Components contribution
     - [ ] Documentation
@@ -92,10 +92,13 @@
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 5 (Aug 27th to Dec 27th)
+### Milestone 5 (from Sep to Dec)
 
 - [ ] Components contribution
     - [ ] More micro service components for image and video
+    - [ ] Fine-tuning support
+    - [ ] Knowledge graph support
+    - [ ] OPEA Playground support
 
 - [ ] UseCases/Examples
     - [ ] More use cases like language translation and AudioQnA
@@ -109,10 +112,11 @@
     - [ ] End2End evaluation 
 
 
-### Milestone 6 (Jan 6th to Aug 29th, 2025)
+### Milestone 6 (2025)
 
 - [ ] Components contribution
     - [ ] More micro service components per community request
+    - [ ] AI Agent support
 
 - [ ] UseCases/Examples
     - [ ] No code solution (GenAIStudio) 


### PR DESCRIPTION
This PR is used to revise the 2024 OPEA roadmap