### PR TITLE
Update 2024 OPEA roadmap to latest status

### DIFF
--- a/roadmap/2024-2025.md
+++ b/roadmap/2024-2025.md
@@ -1,6 +1,6 @@
 ## OPEA 2024 - 2025 Roadmap
 
-### Milestone 1 (May)
+### Milestone 1 (May, Done)
 
 - [x] Components contribution
     - [x] ASR
@@ -19,16 +19,15 @@
     - [x] CodeGen
     - [x] CodeTrans 
 
-- [ ] Cloud Native
-    - [ ] OneClickOPEA on ChatQnA
-    - [ ] OneClickOPEA on CodeGen
+- [x] Cloud Native
+    - [x] OneClickOPEA on ChatQnA
+    - [x] OneClickOPEA on CodeGen
 
-- [ ] Evaluation & Others
-    - [ ] CICD & Validation
-    - [ ] lm-eval-harness
-    - [ ] bigcode-eval-harness
-    - [ ] End2End evaluation on GenAIComps & GenAIExamples
-    - [ ] RAG evaluation
+- [x] Evaluation & Others
+    - [x] CICD & Validation
+    - [x] lm-eval-harness
+    - [x] bigcode-eval-harness
+    - [x] End2End evaluation on GenAIComps & GenAIExamples
 
 ### Milestone 2 (June)
 
@@ -51,6 +50,7 @@
 - [ ] Evaluation & Others
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
+    - [ ] RAG evaluation
 
 ### Milestone 3 (July)
 


### PR DESCRIPTION
This PR updates the latest status of OPEA 2024 roadmap.