### PR TITLE
Update v0.7.md

### DIFF
--- a/release_notes/v0.7.md
+++ b/release_notes/v0.7.md
@@ -1,10 +1,12 @@
-# OPEA Highlights
+## OPEA Highlights
+
 - Add 3 MegaService examples: Translation, SearchQnA and AudioQnA
 - Add 4 MicroService and LLM supports llamaIndex, vllm, RayServe
 - Enable Dataprep: extract info from table, image...etc
 - Add HelmChart and GenAI Microservice Connector(GMC) test
 
-# GenAIExamples 
+## GenAIExamples 
+
 - ChatQnA
     - ChatQnA supports Qwen2([422b4b](https://github.com/opea-project/GenAIExamples/commit/422b4bc56b4e5500538b3d75209320d0a415483b))
     - Add no_proxy in docker compose yaml for micro services([99eb6a](https://github.com/opea-project/GenAIExamples/commit/99eb6a6a7eab4a6d24cbb47d4a541ff4aef41b57), [240587](https://github.com/opea-project/GenAIExamples/commit/240587932b04adeaf740d70229dd27ebd42d5dcd))
@@ -32,7 +34,8 @@
     - Add build docker image option for test scripts([e32a51](https://github.com/opea-project/GenAIExamples/commit/e32a51451c38c35ee4bf27e58cb47f824821ce8d))
     - Add e2e test of chatqna([afcb3a](https://github.com/opea-project/GenAIExamples/commit/afcb3a)), codetrans([295b818](https://github.com/opea-project/GenAIExamples/commit/295b818)), codegen([960cf38](https://github.com/opea-project/GenAIExamples/commit/960cf38)), docsum([2e62ecc](https://github.com/opea-project/GenAIExamples/commit/2e62ecc)))
 
-# GenAIComps 
+## GenAIComps 
+
 - Cores
     - Add aio orchestrator to boost concurrent serving([db3b4f](https://github.com/opea-project/GenAIComps/commit/db3b4f13fa8fc258236d4cc504f1a083d5fd95df))
     - Add microservice level perf statistics([597b3c](https://github.com/opea-project/GenAIComps/commit/597b3ca7d243ff74ce108ded6255e73df01d2486), [ba1d11](https://github.com/opea-project/GenAIComps/commit/ba1d11d93299f2b1d5e53f747aed73cff0384dda))
@@ -84,13 +87,15 @@
     - Add codecov([da2689](https://github.com/opea-project/GenAIComps/commit/da2689))
     - Enable microservice docker images auto build and push([16c5fd](https://github.com/opea-project/GenAIComps/commit/16c5fd))
 
-# GenAIEvals 
+## GenAIEvals 
+
 - Enable autorag to automatically generate the evaluation dataset and evaluate the RAG system([b24bff](https://github.com/opea-project/GenAIEval/commit/b24bff))
 - Support document summarization evaluation with microservice([3ec544](https://github.com/opea-project/GenAIEval/commit/3ec544))
 - Add RAGASMetric([7406bf](https://github.com/opea-project/GenAIEval/commit/7406bf))
 - Update install bkc([26ddcc](https://github.com/opea-project/GenAIEval/commit/26ddcc))
 
-# GenAIInfra 
+## GenAIInfra 
+
 - GMC
     - Enable gmc e2e for manifests changes and some minor fix ([758432](https://github.com/opea-project/GenAIInfra/commit/758432))
     - GMC: make "namespace" field of each resource in the CR optional ([7073ac](https://github.com/opea-project/GenAIInfra/commit/7073ac))


### PR DESCRIPTION
Trivial edits to fix markdown usage 
* level 1 heading as title
* level 2 headings for other subheadings

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>