### PR TITLE
doc: fix use of headings in release notes

### DIFF
--- a/release_notes/v0.6.md
+++ b/release_notes/v0.6.md
@@ -1,21 +1,28 @@
-# OPEA Highlight
+# OPEA Release Notes v0.6
+
+## OPEA Highlight
+
 * Add 4 MegaService examples: CodeGen, ChatQnA, CodeTrans and Docsum, you can deploy them on Kubernetes
 * Enable 10 microservices for LLM, RAG, security...etc
-* Support text generation, code generation and end-to-end evaluation 
+* Support text generation, code generation and end-to-end evaluation
 
-# GenAIExamples 
+## GenAIExamples
+
 * Build 4 reference solutions for some classic GenAI applications, like code generation, chat Q&A, code translation and document summarization, through orchestration interface in GenAIComps.
 * Support seamlessly deployment on Intel Xeon and Gaudi platform through Kubernetes and Docker Compose.
- 
-# GenAIComps 
+
+## GenAIComps
+
 * Activate a suite of microservices including ASR, LLMS, Rerank, Embedding, Guardrails, TTS, Telemetry, DataPrep, Retrieval, and VectorDB. ASR functionality is fully operational on Xeon architecture, pending readiness on Gaudi. Retrieval capabilities are functional on LangChain, awaiting readiness on LlamaIndex. VectorDB functionality is supported on Redis, Chroma, and Qdrant, with readiness pending on SVS.
 * Added 14 file formats support in data preparation microservices and enabled Safeguard of conversation in guardrails.
 * Added the Ray Gaudi Supported for LLM Service.
 
-# GenAIEvals 
+## GenAIEvals
+
 * Add evaluating the models on text-generation tasks(lm-evaluation-harness) and coding tasks (bigcode-evaluation-harness)
 * Add end-to-end evaluation with microservice
 
-# GenAIInfra 
+## GenAIInfra
+
 * Add Helm Charts redis-vector-db, TEI, TGI and CodeGen for deploying GenAIExamples on Kubernetes
 * Add Manifests for deploying GenAIExamples CodeGen, ChatQnA and Docsum on Kubernetes and on Docker Compose

--- a/release_notes/v0.7.md
+++ b/release_notes/v0.7.md
@@ -1,10 +1,14 @@
-# OPEA Highlights
+# OPEA Release Notes v0.7
+
+## OPEA Highlights
+
 - Add 3 MegaService examples: Translation, SearchQnA and AudioQnA
 - Add 4 MicroService and LLM supports llamaIndex, vllm, RayServe
 - Enable Dataprep: extract info from table, image...etc
 - Add HelmChart and GenAI Microservice Connector(GMC) test
 
-# GenAIExamples 
+## GenAIExamples
+
 - ChatQnA
     - ChatQnA supports Qwen2([422b4b](https://github.com/opea-project/GenAIExamples/commit/422b4bc56b4e5500538b3d75209320d0a415483b))
     - Add no_proxy in docker compose yaml for micro services([99eb6a](https://github.com/opea-project/GenAIExamples/commit/99eb6a6a7eab4a6d24cbb47d4a541ff4aef41b57), [240587](https://github.com/opea-project/GenAIExamples/commit/240587932b04adeaf740d70229dd27ebd42d5dcd))
@@ -12,7 +16,7 @@
     - Add Nvidia GPU support for ChatQnA([e80e56](https://github.com/opea-project/GenAIExamples/commit/e80e567817439af1b70b56ff4a60fa58c24e2439))
     - Update ChatQnA docker_compose.yaml to fix downloads failing([e948a7](https://github.com/opea-project/GenAIExamples/commit/e948a7f81b2b68e62b09ad66be35414bf04babd5), [f2a943](https://github.com/opea-project/GenAIExamples/commit/f2a94377aa5e9850a7590c31fd8613f65fdef83c))
     - Chat QNA React UI with conversation history([b994bc](https://github.com/opea-project/GenAIExamples/commit/b994bc87318f245a07e099b395fa49ca3f36baba))
-    - Adapt Chinese characters([2f4723](https://github.com/opea-project/GenAIExamples/commit/2f472315fdd4934b4f50b6120a0d583000d7751c))  
+    - Adapt Chinese characters([2f4723](https://github.com/opea-project/GenAIExamples/commit/2f472315fdd4934b4f50b6120a0d583000d7751c))
 
 - Other examples
     - Refactor Translation Example([409c723](https://github.com/opea-project/GenAIExamples/commit/409c72350e84867ca1ea555c327fe13d00afd926))
@@ -32,7 +36,8 @@
     - Add build docker image option for test scripts([e32a51](https://github.com/opea-project/GenAIExamples/commit/e32a51451c38c35ee4bf27e58cb47f824821ce8d))
     - Add e2e test of chatqna([afcb3a](https://github.com/opea-project/GenAIExamples/commit/afcb3a)), codetrans([295b818](https://github.com/opea-project/GenAIExamples/commit/295b818)), codegen([960cf38](https://github.com/opea-project/GenAIExamples/commit/960cf38)), docsum([2e62ecc](https://github.com/opea-project/GenAIExamples/commit/2e62ecc)))
 
-# GenAIComps 
+## GenAIComps
+
 - Cores
     - Add aio orchestrator to boost concurrent serving([db3b4f](https://github.com/opea-project/GenAIComps/commit/db3b4f13fa8fc258236d4cc504f1a083d5fd95df))
     - Add microservice level perf statistics([597b3c](https://github.com/opea-project/GenAIComps/commit/597b3ca7d243ff74ce108ded6255e73df01d2486), [ba1d11](https://github.com/opea-project/GenAIComps/commit/ba1d11d93299f2b1d5e53f747aed73cff0384dda))
@@ -84,13 +89,15 @@
     - Add codecov([da2689](https://github.com/opea-project/GenAIComps/commit/da2689))
     - Enable microservice docker images auto build and push([16c5fd](https://github.com/opea-project/GenAIComps/commit/16c5fd))
 
-# GenAIEvals 
+## GenAIEvals
+
 - Enable autorag to automatically generate the evaluation dataset and evaluate the RAG system([b24bff](https://github.com/opea-project/GenAIEval/commit/b24bff))
 - Support document summarization evaluation with microservice([3ec544](https://github.com/opea-project/GenAIEval/commit/3ec544))
 - Add RAGASMetric([7406bf](https://github.com/opea-project/GenAIEval/commit/7406bf))
 - Update install bkc([26ddcc](https://github.com/opea-project/GenAIEval/commit/26ddcc))
 
-# GenAIInfra 
+## GenAIInfra
+
 - GMC
     - Enable gmc e2e for manifests changes and some minor fix ([758432](https://github.com/opea-project/GenAIInfra/commit/758432))
     - GMC: make "namespace" field of each resource in the CR optional ([7073ac](https://github.com/opea-project/GenAIInfra/commit/7073ac))
@@ -116,4 +123,3 @@
    - Enable golang e2e test in CI ([bc9aba](https://github.com/opea-project/GenAIInfra/commit/bc9aba))
    - Add e2e test for docsum example ([89aa5a](https://github.com/opea-project/GenAIInfra/commit/89aa5a))
    - Add docsum example on both xeon and gaudi node ([c88817](https://github.com/opea-project/GenAIInfra/commit/c88817))
-


### PR DESCRIPTION
First (and only) H1 heading is expected to be the document title