### PR TITLE
doc: fix headings

### DIFF
--- a/roadmap/2024-2025.md
+++ b/roadmap/2024-2025.md
@@ -1,6 +1,6 @@
-## OPEA 2024 - 2025 Roadmap
+# OPEA 2024 - 2025 Roadmap
 
-### Milestone 1 (May, Done)
+## Milestone 1 (May, Done)
 
 - [x] Components contribution
     - [x] ASR
@@ -29,7 +29,7 @@
     - [x] bigcode-eval-harness
     - [x] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 2 (June)
+## Milestone 2 (June)
 
 - [ ] Components contribution
     - [ ] LLM on Xeon by vLLM + Ray, Ollama
@@ -52,7 +52,7 @@
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
     - [ ] RAG evaluation
 
-### Milestone 3 (July)
+## Milestone 3 (July)
 
 - [ ] Components contribution
     - [ ] LLM on Gaudi by vLLM + Ray
@@ -73,7 +73,7 @@
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 4 (Aug)
+## Milestone 4 (Aug)
 
 - [ ] Components contribution
     - [ ] Documentation
@@ -92,7 +92,7 @@
     - [ ] CICD & Validation
     - [ ] End2End evaluation on GenAIComps & GenAIExamples
 
-### Milestone 5 (from Sep to Dec)
+## Milestone 5 (from Sep to Dec)
 
 - [ ] Components contribution
     - [ ] More micro service components for image and video
@@ -112,7 +112,7 @@
     - [ ] End2End evaluation 
 
 
-### Milestone 6 (2025)
+## Milestone 6 (2025)
 
 - [ ] Components contribution
     - [ ] More micro service components per community request

--- a/roadmap/CICD.md
+++ b/roadmap/CICD.md
@@ -1,12 +1,12 @@
-## OPEA CI/CD Roadmap
+# OPEA CI/CD Roadmap
 
-### Milestone 1 (May, Done)
+## Milestone 1 (May, Done)
 - Format scan for GenAIExamples/GenAIComps/GenAIInfra/GenAIEval
 - Security scan for GenAIExamples/GenAIComps/GenAIInfra/GenAIEval
 - Unit test for GenAIComps/GenAIInfra/GenAIEval
 - E2E test for GenAIExamples/GenAIComps/GenAIInfra milestone1 related scope
 
-### Milestone 2 (June)
+## Milestone 2 (June)
 - CI infrastructure optimization
 - k8s multi-node cluster on 2 Xeon node for CI
 - k8s multi-node cluster on 2 Gaudi node for CI
@@ -16,13 +16,13 @@
 - E2E test for GenAIExamples/GenAIComps/GenAIInfra milestone2 related scope
 - RAG benchmark with GenAIEval
 
-### Milestone 3 (July)
+## Milestone 3 (July)
 - Enhance code coverage
 - E2E test for GenAIExamples/GenAIComps/GenAIInfra milestone3 related scope
 - GMC test for k8s
 - k8s scalability test
 
-### Milestone 4 (Aug)
+## Milestone 4 (Aug)
 - Enhance code coverage
 - E2E test for GenAIExamples/GenAIComps/GenAIInfra milestone4 related scope
 - Enhance k8s scalability test


### PR DESCRIPTION
First (and only) H1 heading should be the document title, other headings shouldn't skip levels.