### PR TITLE
doc: prepare for removing Governance repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOC_TAG      ?= development
 RELEASE      ?= latest
 PUBLISHDIR    = $(OPEA_BASE)/opea-project.github.io/$(RELEASE)
 RSYNC_OPTS    = -am --exclude='.github/*' --include='*/' --include-from=scripts/rsync-include.txt --exclude='*'
-RSYNC_DIRS    = GenAIComps  GenAIEval  GenAIExamples  GenAIInfra  Governance
+RSYNC_DIRS    = GenAIComps  GenAIEval  GenAIExamples  GenAIInfra
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -43,7 +43,7 @@ help:
 # Copy all the rst and md content (and images, etc) into the _build/rst folder
 # including rst and md content
 
-# GenAIComps  GenAIEval  GenAIExamples  GenAIInfra  Governance
+# GenAIComps  GenAIEval  GenAIExamples  GenAIInfra
 content:
 	$(Q)mkdir -p $(SOURCEDIR)
 	$(Q)rsync -a --exclude=$(BUILDDIR) . $(SOURCEDIR)

--- a/developer-guides/docbuild.rst
+++ b/developer-guides/docbuild.rst
@@ -30,8 +30,7 @@ The project's documentation contains the following items:
   https://opea-project.github.io website. All of the documentation sources
   are found in the ``github.com/opea-project`` repos, rooted in the ``docs`` repo.
   There's also documentation in the repos where the project's code is
-  maintained: ``GenAIComps``, ``GenAIEval``, ``GenAIExamples``, ``GenAIInfra``
-  and ``Governance``.
+  maintained: ``GenAIComps``, ``GenAIEval``, ``GenAIExamples``, and ``GenAIInfra``.
 
 .. graphviz:: images/doc-gen-flow.dot
    :align: center
@@ -61,7 +60,6 @@ cloned repos from the opea-project:
    ├── GenAIEval
    ├── GenAIExamples
    ├── GenAIInfra
-   ├── Governance
    ├── opea-project.github.io
 
 The parent ``opea-project-docsgen`` folder is there to organize the cloned repos
@@ -78,7 +76,7 @@ this once to set up the folder structure:
 
       cd ~
       mkdir opea-project-docsgen && cd opea-project-docsgen
-      for d in docs GenAIComps GenAIExamples GenAIEval GenAIInfra Governance ; do
+      for d in docs GenAIComps GenAIExamples GenAIEval GenAIInfra ; do
         git clone https://github.com/opea-project/$d.git
       done
 
@@ -278,7 +276,7 @@ repos, and add some extra flags to the ``make`` commands:
 .. code-block:: bash
 
    version=0.8
-   for d in docs GenAIComps GenAIExamples GenAIEval GenAIInfra Governance ; do
+   for d in docs GenAIComps GenAIExamples GenAIEval GenAIInfra ; do
     cd ~/opea-project-docsgen/$d
     git checkout $version
    done


### PR DESCRIPTION
Governance repo content is moved to this docs repo's community folder. Remove references to Governance in doc build documentation and Makefile.