### PR TITLE
doc: add pymarkdown tool

### DIFF
--- a/scripts/checkmd.sh
+++ b/scripts/checkmd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (C) 2024 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use pymarkdown to recursively scan all markdown files for problems
+# Disable rules we don't care to check.  If you find others that you'd like to
+# ignore, simply add them to this list
+
+drules=line-length,no-bare-urls,no-multiple-blanks,blanks-around-fences,no-hard-tabs,blanks-around-headings
+drules=$drules,fenced-code-language,no-duplicate-heading,no-emphasis-as-heading,no-trailing-spaces
+
+pymarkdown --disable-rules $drules scan -r .
+

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,3 +5,4 @@ sphinx-tabs==3.4.5
 myst-parser>=3.0
 sphinx-md==0.0.3
 sphinxcontrib-mermaid
+pymarkdownlnt


### PR DESCRIPTION
pymarkdown provides checks for properly written markdown files. It's quite configurable and checks for many items we choose not to enforce, such as 80 character line length.  It can be configured so a CI system could do checks on markdown files being submitted in a PR, but for now, I'm just including the tool in the list of packages installed from PyPI and a script to call it (scripts/checkmd.sh) with some settings that limit what checks we're interested in (for now).