### PR TITLE
doc: change ChatQnA to use glob for any doc

### DIFF
--- a/examples/ChatQnA/ChatQnA_Guide.rst
+++ b/examples/ChatQnA/ChatQnA_Guide.rst
@@ -165,11 +165,9 @@ Single Node
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
-   deploy/xeon
-   deploy/gaudi
-   deploy/nvidia
-   deploy/AIPC
+   deploy/*
 
 Kubernetes
 ==========


### PR DESCRIPTION
The AIPC doc was changed to aipc (lowercase) and broke the toctree reference, so let's change use all files in the deploy folder instead.