### PR TITLE
doc: configure myst handling of mermaid diagrams

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -44,6 +44,7 @@ extensions = [
 ]
 
 myst_enable_extensions = ["colon_fence"]
+myst_fence_as_directive = ["mermaid"]
 
 # sphinx_md config
 sphinx_md_useGitHubURL = True

--- a/scripts/fix-github-md-refs.sh
+++ b/scripts/fix-github-md-refs.sh
@@ -31,8 +31,8 @@ sed -i 's/(\/docs\//(\//g' $mdfiles
 # sed -i 's/\(\/[a-zA-z]*\))/\1\/README.md)/g' $files
 
 # fix tagging on code blocks, for myst parser (vs. GFM syntax)
-
-sed -i 's/^```mermaid/```{mermaid}/' `grep -ril --include="*.md" '\`\`\`mermaid'`
+# with myst_fence_as_directive = ["mermaid"] we don't need to do this any mre
+# sed -i 's/^```mermaid/```{mermaid}/' `grep -ril --include="*.md" '\`\`\`mermaid'`
 
 # fix references to opea-project/blob/main/... to use the special role # :{repo}_raw:`{path to file}`
 # alas, using sphinx roles doesn't work in markdown files, so leave them alone


### PR DESCRIPTION
Found a configuration of myst that allows me to remove the sed script I was using to tweak handling of mermaid diagrams in markdown (the GitHub Flavored markdown syntax wasn't recognized by the myst-parser extension)