### PR TITLE
doc: remove GenAIInfra placeholder

### DIFF
--- a/community/codeowner.md
+++ b/community/codeowner.md
@@ -15,10 +15,6 @@ about content within a repository.
 
 -----
 
-## GenAIInfra
-
-* mkbhanda, irisdingbj, jfding, ftian1, yongfengdu
-
 ## Continuous Integration (CICD) owners
 
 CI/CD processing is defined and managed by these owners:


### PR DESCRIPTION
GenAIInfra has a CODEOWNERS file now, so remote the manually maintained placeholder.