### PR TITLE
Add CONTRIBUTING.md file to root folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+## Contributing to OPEA
+
+Welcome to the OPEA open-source community! We are thrilled to have you here and excited about the potential contributions you can bring to the OPEA platform. Whether you are fixing bugs, adding new GenAI components, improving documentation, or sharing your unique use cases, your contributions are invaluable.
+
+Together, we can make OPEA the go-to platform for enterprise AI solutions. Let's work together to push the boundaries of what's possible and create a future where AI is accessible, efficient, and impactful for everyone.
+
+Please check the [Contributing guidelines](https://github.com/opea-project/docs/tree/main/community/CONTRIBUTING.md) for a detailed guide on how to contribute a GenAI component and all the ways you can contribute!
+
+Thank you for being a part of this journey. We can't wait to see what we can achieve together!
+
+## Additional Content
+
+- [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)
+- [Security Policy](https://github.com/opea-project/docs/tree/main/community/SECURITY.md)


### PR DESCRIPTION
Add a CONTRIBUTING.md file to the root directory that contains a link to the existing contributor documentation located at docs/community/CONTRIBUTING.md

[#93 ](https://github.com/opea-project/docs/issues/93)