### PR TITLE
Clean up GenAI Examples page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -84,7 +84,7 @@ else:
         # Toc options
         'collapse_navigation': False,
         'sticky_navigation': True,
-        'navigation_depth': 3,
+        'navigation_depth': 4,
     }
 
 

--- a/examples/examples.rst
+++ b/examples/examples.rst
@@ -1,0 +1,15 @@
+Examples
+##########
+
+.. rst-class:: rst-columns
+
+.. contents::
+   :local:
+   :depth: 1
+
+----
+
+.. comment This include file is generated in the Makefile during doc build
+   time from all the directories found in the GenAIExamples top level directory
+
+.. include:: examples.txt

--- a/examples/index.rst
+++ b/examples/index.rst
@@ -23,19 +23,6 @@ We're building this documentation from content in the
    :glob:
 
    /GenAIExamples/README
+   examples.rst
    /GenAIExamples/*
 
-**Example Applications Table of Contents**
-
-.. rst-class:: rst-columns
-
-.. contents::
-   :local:
-   :depth: 1
-
-----
-
-.. comment This include file is generated in the Makefile during doc build
-   time from all the directories found in the GenAIExamples top level directory
-
-.. include:: examples.txt


### PR DESCRIPTION
1. Increase nav depth to 4 to see examples in site nav (conf.py)
2. Move examples section of examples/index.rst to examples.rst
3. Add examples/examples.rst to examples/index.rst toctree