### PR TITLE
allow the cloud folder md files in online doc, rm the warning

### DIFF
--- a/deploy/index.rst
+++ b/deploy/index.rst
@@ -31,6 +31,19 @@ Installation Guides
    ../guide/installation/*
    ../guide/installation/**/*
 
+Cloud Service Provider
+**********************
+
+
+.. rst-class:: rst-columns
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /GenAIInfra/cloud-service-provider/*
+   /GenAIInfra/cloud-service-provider/**/*
+
 Authentication and Authorization
 ********************************
 


### PR DESCRIPTION
This PR fix the online build warning for md files in folder cloud-service-provider: WARNING: document isn't included in any toctree.