### PR TITLE
Support folder with nunber prefix

### DIFF
--- a/scripts/maketoc.sh
+++ b/scripts/maketoc.sh
@@ -50,7 +50,7 @@ ls -d1 */ | \
 
 cd ../GenAIComps/comps
 
-ls -d1 [a-zA-Z]*/ | \
+ls -d1 [a-zA-Z0-9]*/ | \
    awk \
      -v repo="GenAIComps" \
      -e '{dirname=substr($0,1,length($0)-1); title=toupper(substr(dirname,1,1)) substr(dirname,2) " Microservice"; \


### PR DESCRIPTION
It's used to fix the warning: xxx/opea/docs/_build/rst/GenAIComps/comps/3rd_parties/tgi/deployment/docker/README.md: WARNING: document isn't included in any toctree.

The original code don't support the folder with number prefix.