### PR TITLE
fix build online doc CI

### DIFF
--- a/.github/workflows/check-online-doc-build.yml
+++ b/.github/workflows/check-online-doc-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Build Online Document


### PR DESCRIPTION
fix the build error issue, due to default ubuntu is upgraded to 24.
Use ubuntu-22.04 in CI.