### PR TITLE
doc:Add emeritus code owners page

### DIFF
--- a/community/codeowner_emeritus.md
+++ b/community/codeowner_emeritus.md
@@ -1,0 +1,16 @@
+# OPEA Emeritus Code Owners
+
+The table below acknowledges the OPEA code owners who have left, and whose valuable contributions were crucial to the project's success. We are deeply grateful!
+
+
+| Repo                        | Path                          | Emeritus Owner                      |
+|-----------------------------|-------------------------------|-------------------------------------|
+| docs                        | `*`                           |  david.b.kinder@intel.com           |
+| GenAIInfra                  | `*`                           |  iris.ding@intel.com                |
+| GenAIInfra                  | `/microservices-connector/`   |  kefei.zhang@intel.com              |
+| GenAIInfra                  | `/microservices-connector/`   |  huailong.zhang@intel.com           |
+
+
+
+
+

--- a/community/codeowner_emeritus.md
+++ b/community/codeowner_emeritus.md
@@ -9,8 +9,3 @@ The table below acknowledges the OPEA code owners who have left, and whose valua
 | GenAIInfra                  | `*`                           |  iris.ding@intel.com                |
 | GenAIInfra                  | `/microservices-connector/`   |  kefei.zhang@intel.com              |
 | GenAIInfra                  | `/microservices-connector/`   |  huailong.zhang@intel.com           |
-
-
-
-
-

--- a/community/index.rst
+++ b/community/index.rst
@@ -52,6 +52,7 @@ Contributing Guides
    CONTRIBUTING
    add_vectorDB
    codeowner
+   codeowner_emeritus
    SECURITY
 
 Roadmaps


### PR DESCRIPTION
[Bug: 291]  Add  emeritus code owners page

This feat adds one page to list emeritus code owners

The code owners are 39 in total, we use Teams to filter folks whom couldn't be searched and then list related repo/path/email info  in emeritus code owners page.

Fixes #291

Signed-off-by: Ma,YaZhan <yazhan.ma@intel.com>
Signed-off-by: Gao, Fengqian <fengqian.gao@intel.com>
Signed-off-by: Chen, Xiaotian <xiaotian.chen@intel.com>