### PR TITLE
Add AMD OPEA blog

### DIFF
--- a/blogs/index.rst
+++ b/blogs/index.rst
@@ -12,6 +12,9 @@ Come learn, try, develop, and share your stories! Please submit PRs, organizing 
    * - Date
      - URL
      - Authors
+   * - 03/12/2025
+     - `AMD Advances Enterprise AI Through OPEA Integration <https://rocm.blogs.amd.com/artificial-intelligence/-opea-blog/README.html>`_
+     - Yu Wang, Alex He
    * - 02/26/2025
      - `Multimodal Q&A: A Step-by-Step Guide <https://www.intel.com/content/www/us/en/developer/articles/technical/multimodal-q-and-a-step-by-step-guide.html>`_
      - Melanie Hart Buehler, Mustafa Cetin, Dina Suehiro Jones


### PR DESCRIPTION
This change adds the link to AMD's first OPEA blog titled AMD Advances Enterprise AI Through OPEA Integration at https://rocm.blogs.amd.com/artificial-intelligence/-opea-blog/README.html by Yu Wang and Alex He.