### PR TITLE
Update docs to clone or download from latest v1.3 everywhere

### DIFF
--- a/tutorial/ChatQnA/deploy/add_vector_db.md
+++ b/tutorial/ChatQnA/deploy/add_vector_db.md
@@ -370,11 +370,11 @@ Follow the instructions to validate MicroServices.
 
 #### Dataprep Microservice（Optional）
 If you want to update the default knowledge base, you can use the following commands:
-Update Knowledge Base via Local File [nke-10k-2023.pdf](https://github.com/opea-project/GenAIComps/blob/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf). Or
-click [here](https://raw.githubusercontent.com/opea-project/GenAIComps/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf) to download the file via any web browser Or run this command to get the file on a terminal.
+Update Knowledge Base via Local File [nke-10k-2023.pdf](https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf). Or
+click [here](https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf) to download the file via any web browser Or run this command to get the file on a terminal.
 
 ```bash
-wget https://raw.githubusercontent.com/opea-project/GenAIComps/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf
+wget https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf
 ```
 
 Upload:

--- a/tutorial/ChatQnA/deploy/aipc.md
+++ b/tutorial/ChatQnA/deploy/aipc.md
@@ -338,7 +338,7 @@ The knowledge base can be updated using the dataprep microservice, which extract
 
 `nke-10k-2023.pdf` is Nike's annual report on a form 10-K. Run this command to download the file:
 ```bash
-wget https://github.com/opea-project/GenAIComps/blob/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf
+wget https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf
 ```
 
 Upload the file:

--- a/tutorial/ChatQnA/deploy/gaudi.md
+++ b/tutorial/ChatQnA/deploy/gaudi.md
@@ -343,7 +343,7 @@ The knowledge base can be updated using the dataprep microservice, which extract
 
 `nke-10k-2023.pdf` is Nike's annual report on a form 10-K. Run this command to download the file:
 ```bash
-wget https://github.com/opea-project/GenAIComps/blob/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf
+wget https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf
 ```
 
 Upload the file:

--- a/tutorial/ChatQnA/deploy/nvidia.md
+++ b/tutorial/ChatQnA/deploy/nvidia.md
@@ -246,7 +246,7 @@ The knowledge base can be updated using the dataprep microservice, which extract
 
 `nke-10k-2023.pdf` is Nike's annual report on a form 10-K. Run this command to download the file:
 ```bash
-wget https://github.com/opea-project/GenAIComps/blob/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf
+wget https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf
 ```
 
 Upload the file:

--- a/tutorial/ChatQnA/deploy/xeon.md
+++ b/tutorial/ChatQnA/deploy/xeon.md
@@ -306,7 +306,7 @@ The knowledge base can be updated using the dataprep microservice, which extract
 
 `nke-10k-2023.pdf` is Nike's annual report on a form 10-K. Run this command to download the file:
 ```bash
-wget https://github.com/opea-project/GenAIComps/blob/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf
+wget https://github.com/opea-project/GenAIComps/blob/v1.3/comps/third_parties/pathway/src/data/nke-10k-2023.pdf
 ```
 
 Upload the file:


### PR DESCRIPTION
## Description
Since v1.3 is out, we want to encourage users to use the latest version by making references to that version whenever there's a `git clone` for example.
Otherwise if they copy and paste commands then, they may not nessasirity using the latest version.

## Issues
N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies
N/A

## Tests
Most likely just docs build is what's needed for this one before merge.