### PR TITLE
merge blog, fix chapter error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please check the [Contributing guidelines](https://github.com/opea-project/docs/
 
 Thank you for being a part of this journey. We can't wait to see what we can achieve together!
 
-# Additional Content
+## Additional Content
 
 - [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)
 - [Security Policy](https://github.com/opea-project/docs/tree/main/community/SECURITY.md)

--- a/index.rst
+++ b/index.rst
@@ -80,6 +80,5 @@ Source code for the OPEA Project is maintained in the
    release_notes/index
    CONTRIBUTING
    faq
-   blogs/index
 
 .. _OPEA Project GitHub repository: https://github.com/opea-project

--- a/publish/blog.rst
+++ b/publish/blog.rst
@@ -1,8 +1,3 @@
-.. _opea_blogs:
-
-OPEA Blogs
-##########
-
 Come learn, try, develop, and share your stories! Please submit PRs, organizing content in reverse chronological order.
 
 .. list-table:: Trending Blogs
@@ -14,7 +9,7 @@ Come learn, try, develop, and share your stories! Please submit PRs, organizing 
      - Authors
    * - 04/18/2025
      - `省钱还高效！OPEA+Dify在Intel® Arc™ GPU上构建基于DeepSeek的RAG工作流 <https://mp.weixin.qq.com/s/g71trKXM-yohse-FcfeZ6A>`_
-     - Qiang Ren 
+     - Qiang Ren
    * - 04/15/2025
      - `Build Your First Chatbot with OPEA In Minutes <https://www.intel.com/content/www/us/en/developer/articles/guide/build-your-first-chatbot-with-opea-in-minutes.html>`_
      - Wang Xigui, Bhandaru Malini, Sin Alex, Du dolpher, Yao Yi, Hu Ying
@@ -48,6 +43,9 @@ Come learn, try, develop, and share your stories! Please submit PRs, organizing 
    * - 02/12/2025
      - `Deploy a DeepSeek-R1 Distill Chatbot on AWS Xeon <https://www.intel.com/content/www/us/en/developer/articles/guide/deploy-a-deepseek-r1-distill-chatbot-on-aws-xeon.html>`_
      - Alex Sin
+   * - 01/24/2025
+     - `OPEA Blogs <https://opea.dev/news>`_
+     - OPEA Team
    * - 10/14/2024
      - `Harness Enterprise GenAI Using OPEA <https://vmblog.com/archive/2024/10/14/harness-enterprise-genai-using-opea.aspx>`_
      - Iris Ding, Malini Bhandaru

--- a/publish/index.rst
+++ b/publish/index.rst
@@ -14,25 +14,7 @@ https://opea.dev/community-events/
 Blogs
 *****************
 
-.. list-table:: Blogs
-   :widths: 5 65 30
-   :header-rows: 1
-
-   * - Date
-     - Link
-     - Authors
-   * - [02/26/2025]
-     - `Multimodal Question and Answer - A Step-by-Step Guide with OPEA 1.2 and Intel Gaudi 2 <https://www.intel.com/content/www/us/en/developer/articles/technical/multimodal-q-and-a-step-by-step-guide.html>`_
-     - Melanie Hart Buehler, Mustafa Cetin, Dina Suehiro Jones
-   * - [02/12/2025]
-     - `Deploy a DeepSeek-R1-Distill Chatbot in Minutes on Low-Cost AWS Xeon Instances <https://www.intel.com/content/www/us/en/developer/articles/guide/deploy-a-deepseek-r1-distill-chatbot-on-aws-xeon.html>`_
-     - Alex Sin
-   * - [01/24/2025]
-     - `OPEA Blogs <https://opea.dev/news>`_
-     - OPEA Team
-   * - [10/14/2024]
-     - `Harness Enterprise GenAI Using OPEA <https://vmblog.com/archive/2024/10/14/harness-enterprise-genai-using-opea.aspx>`_
-     - Iris Ding, Malini Bhandaru
+.. include:: ./blog.rst
 
 Demos and Videos
 *****************


### PR DESCRIPTION
Fix two issues:
https://github.com/opea-project/docs/issues/358
Solution: 
Merge the Blogs and Publications/blogs to Publications/blogs. The content of removed "Blogs" is merged to Publications/blogs.

https://github.com/opea-project/docs/issues/380
Solution: 
Move the chapter "additional content" to second level.


