### PR TITLE
Remove reference to non-existing "chatqna_wrapper.py" file

### DIFF
--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -248,7 +248,6 @@ flowchart LR
     │   └── performance
     │       └── kubernetes
     ├── chatqna.py    # Main application definition (microservices, megaservice, gateway).
-    ├── chatqna_wrapper.py
     ├── docker_compose
     │   ├── amd
     │   │   └── gpu


### PR DESCRIPTION
PR https://github.com/opea-project/GenAIExamples/pull/2190 will remove the referenced obsolete file.

No other application currently has files called `*_wrapper.py`, so it's not relevant as example for them either.